### PR TITLE
Avoid memory explosion using chunked arrays and indexers with small memory footprint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.egg-info/
 build/
 data/
+.venv/

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ pandas >= 1.2
 numpy
 matplotlib
 geopandas
+dask
 xarray
 rasterio
 rioxarray

--- a/src/gregor/disaggregate.py
+++ b/src/gregor/disaggregate.py
@@ -60,8 +60,13 @@ def disaggregate_polygon_to_raster(
     # one DataArray, float32, chunked
     proxy_da = proxy_da.astype("float32").chunk({"y": chunk_size, "x": chunk_size})
 
-    # raster of polygon IDs (int32, same chunks)
-    belongs_to = get_belongs_to_matrix(proxy_da, gdf.geometry)
+    # raster of polygon IDs ─ always burn row numbers (0…n‑1)
+    if not np.issubdtype(gdf.index.dtype, np.integer):
+        geom_id_source = gdf.reset_index(drop=True).geometry  # integer IDs
+    else:
+        geom_id_source = gdf.geometry
+
+    belongs_to = get_belongs_to_matrix(proxy_da, geom_id_source)
     belongs_to = belongs_to.where(~belongs_to.isnull(), other=-1)
     belongs_to = belongs_to.astype("int32").chunk(proxy_da.chunks)
 

--- a/src/gregor/disaggregate.py
+++ b/src/gregor/disaggregate.py
@@ -61,11 +61,9 @@ def disaggregate_polygon_to_raster(
     proxy_da = proxy_da.astype("float32").chunk({"y": chunk_size, "x": chunk_size})
 
     # raster of polygon IDs (int32, same chunks)
-    belongs_to = (
-        get_belongs_to_matrix(proxy_da, gdf.geometry)
-        .astype("int32")
-        .chunk(proxy_da.chunks)
-    )
+    belongs_to = get_belongs_to_matrix(proxy_da, gdf.geometry)
+    belongs_to = belongs_to.where(~belongs_to.isnull(), other=-1)
+    belongs_to = belongs_to.astype("int32").chunk(proxy_da.chunks)
 
     # ───────────────────── zonal sums per polygon ───────────────────────
     max_id = int(belongs_to.max().compute())  # get the 'true' maximum

--- a/src/gregor/disaggregate.py
+++ b/src/gregor/disaggregate.py
@@ -103,7 +103,6 @@ def disaggregate_polygon_to_raster(
     val_full = np.zeros(n_ids + 1, dtype="float32")  # +1 sentinel (-1)
     norm_full = np.zeros(n_ids + 1, dtype="float32")
 
-    val_full[gdf.index.values.astype(int)] = gdf[column].astype("float32").values
     val_full[: len(gdf)] = gdf[column].astype("float32").values
     norm_full[:n_ids] = normalization.values
 

--- a/test/test_disaggregate.py
+++ b/test/test_disaggregate.py
@@ -45,10 +45,10 @@ def test_disaggregate_2x2(dummy_raster, square_segmentation_2x2):
     )
 
     assert (
-        disaggregated.coarsen(x=2, y=2).sum()["value"].values == [[2, 2], [2, 2]]
+        disaggregated.coarsen(x=2, y=2).sum().values == [[2, 2], [2, 2]]
     ).all()
 
-    assert np.allclose(disaggregated["value"].values, expected)
+    assert np.allclose(disaggregated.values, expected)
 
 
 def test_disaggregate_3x3():


### PR DESCRIPTION
This PR aims to improve the `disaggregate_polygon_to_raster` by removing the `groupby` normalisation operation, and instead rasterising the shapes and then performing the normalisation in a vectorised way.

The improvements significantly reduce the memory footprint, and allow 'larger than memory' cases to execute thanks to the "chunked" approach.

Here are two examples of the results on a 16 GB RAM laptop with an i7 13k core.
Please ignore the figure titles, I had a small bug that did not display the coarsened pixel count 😬

**Key changes:**
- `disaggregate_polygon_to_raster` now expects a DataArray (not a `Dataset`). If a `Dataset` is given, it'll only process it if it contains one variable.
- Added `dask` to the dependencies.

## Proxy of all of Europe (estimated 'missing' PV rooftop capacity)

This case was previously impossible to run. Both RAM and Swap were filled, leading to a crash.
With `dask`, the memory footprint never exceeds the available memory capacity.

<img width="1891" height="1022" alt="image" src="https://github.com/user-attachments/assets/62f007db-49a4-4a10-9424-857e3f572930" />

<img width="1800" height="1800" alt="rooftop_pv" src="https://github.com/user-attachments/assets/1cb872b3-c129-4f2e-a0fd-c459663ccbff" />

## Proxy of Montenegro

A smaller case that I was able to run in the previous approach.

### Before

<img width="1800" height="1800" alt="rooftop_pv (jann v0 0 2)" src="https://github.com/user-attachments/assets/a7147a9f-55c3-4630-b4c1-b430dd16cda4" />

### After

<img width="1800" height="1800" alt="rooftop_pv" src="https://github.com/user-attachments/assets/19464440-f4a4-481f-9d9c-70726095ff02" />
