### PR TITLE
Fix warnings: DeprecationWarning and prints use warnings.warn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 build/
 data/
 .venv/
+**/tmp/*

--- a/src/gregor/disaggregate.py
+++ b/src/gregor/disaggregate.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import dask.array as da
 import geopandas as gpd
 import numpy as np
@@ -38,8 +40,9 @@ def disaggregate_polygon_to_raster(
         _proxy = proxy
     elif isinstance(proxy, xr.Dataset):
         if len(proxy.data_vars) == 1:
-            raise DeprecationWarning(
-                "Passing DataSet is deprecated and will be disallowed in the future. Use DataArray instead."
+            warn(
+                "Passing DataSet is deprecated and will be disallowed in the future. Use DataArray instead.",
+                category=DeprecationWarning,
             )
             var_name = next(iter(proxy.data_vars))
             _proxy = proxy[var_name]
@@ -62,7 +65,7 @@ def disaggregate_polygon_to_raster(
 
     # make sure that crs of data and proxy match
     if _proxy.rio.crs != _data.crs:
-        print(
+        warn(
             f"CRS of `data` ({_data.crs}) does not match CRS of `proxy` ({_proxy.rio.crs}). Reprojecting CRS of `data` to match `proxy`'s CRS."
         )
         _data = _data.to_crs(_proxy.rio.crs)
@@ -111,7 +114,7 @@ def disaggregate_polygon_to_raster(
     )
 
     if to_data_crs and _proxy.rio.crs != data.crs:
-        print(f"Reprojecting results to `data`'s CRS {data.crs}.")
+        warn(f"Reprojecting results to `data`'s CRS {data.crs}.")
         raster = raster.rio.reproject(data.crs)
 
     return raster
@@ -217,7 +220,7 @@ def disaggregate_polygon_to_point(
 
     # compare crs. If not the same, project data to proxy's crs
     if not proxy.crs == _data.crs:
-        print(
+        warn(
             f"CRS of `proxy` ({proxy.crs}) does not match CRS of `data` ({_data.crs}). Reprojecting CRS of `data` to `proxy`'s CRS."
         )
         _data = _data.to_crs(proxy.crs)
@@ -255,7 +258,7 @@ def disaggregate_polygon_to_point(
     points = points[["geometry", "disaggregated"]]
 
     if to_data_crs:
-        print(f"Reprojecting results to `data`'s CRS {_data.crs}.")
+        warn(f"Reprojecting results to `data`'s CRS {_data.crs}.")
         points = points.to_crs(_data.crs)
 
     return points


### PR DESCRIPTION
Small PR with some fixes:
- `print` messages in `disaggregate.py` now use python's `warn` so `stderr` catches them.
- `DeprecationWarning` was a "dead" case due to the use of `raise`, later code was unreachable. It is now a warning of the correct type, so the code continues, implementing the fix after the warning.
- added `**/tmp/*` to `.gitignore` so test code files do not show up in `git`.